### PR TITLE
Get content

### DIFF
--- a/js/download.js
+++ b/js/download.js
@@ -48,6 +48,10 @@ function getContent(uuid) {
 
                 if ((status >= 200 && status < 300) || status === 304) {
                     var doc = JSON.parse(xhr.responseText);
+                    // workaround for older ws version what shows root variable
+                    if (typeof doc.document !== 'undefined') {
+                        doc = doc.document;
+                    }
                     mimeType = doc.mimeType;
                     docName = getName(doc.path);
                 } else {

--- a/js/download.js
+++ b/js/download.js
@@ -22,7 +22,7 @@ function getName(nodePath) {
 }
 
 // getContent based on http://stackoverflow.com/questions/17696516/download-binary-files-with-javascript
-function getContent(uuid) {
+function getContent(uuid, isBrowserPreview) {
     // Grabbing the configuration
     chrome.storage.sync.get("config", function (storage) {
         var dictConfig = storage["config"];
@@ -79,7 +79,12 @@ function getContent(uuid) {
                     if (this.status === 200) {
                         var blob = new Blob([xhr.response], {type: mimeType, name: docName});
                         var objectUrl = URL.createObjectURL(blob);
-                        window.open(objectUrl);
+                        if (isBrowserPreview) {
+                            window.open(objectUrl);
+                        } else {
+                            var iframe = document.getElementById("__download");
+                            iframe.src = objectUrl;
+                        }
                     }
                 };
                 

--- a/js/download.js
+++ b/js/download.js
@@ -1,0 +1,88 @@
+/*
+     _ _____      _     _
+    (_)___ /_   _(_)___(_) ___         ___ ___  _ __ ___
+    | | |_ \ \ / / / __| |/ _ \       / __/ _ \| '_ ` _ \
+    | |___) \ V /| \__ \ | (_) |  _  | (_| (_) | | | | | |
+    |_|____/ \_/ |_|___/_|\___/  (_)  \___\___/|_| |_| |_|
+    Copyright 2016 Félix Brezo and Yaiza Rubio (i3visio, contacto@i3visio.com)
+    This file is part of Kamify. You can redistribute it and/or 
+    modify it under the terms of the GNU General Public License as published 
+    by the Free Software Foundation, either version 3 of the License, or (at 
+    your option) any later version.
+    This program is distributed in the hope that it will be useful, but 
+    WITHOUT ANY WARRANTY; without even the implied warranty of 
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General 
+    Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+function getName(nodePath) {
+    return nodePath.substring(nodePath.lastIndexOf('/')+1)
+}
+
+// getContent based on http://stackoverflow.com/questions/17696516/download-binary-files-with-javascript
+function getContent(uuid) {
+    // Grabbing the configuration
+    chrome.storage.sync.get("config", function (storage) {
+        var dictConfig = storage["config"];
+        
+        var url = dictConfig["profiles"][dictConfig["currentProfile"]]["url"];
+        var userName = dictConfig["profiles"][dictConfig["currentProfile"]]["username"];
+        var password = dictConfig["profiles"][dictConfig["currentProfile"]]["password"];
+        
+        // Getting the mime type and document name
+        var mimeType = "";
+        var docName = "";
+        var requestUrl = url + "services/rest/document/getProperties?docId=" + uuid;
+
+        var xhr = new XMLHttpRequest();
+        xhr.open("GET", requestUrl, false);
+
+        xhr.setRequestHeader("Authorization", "Basic " + btoa(userName + ":" + password));
+        xhr.setRequestHeader("Accept", "application/json; indent=4");
+        
+        xhr.onreadystatechange = function() {
+            if (xhr.readyState === 4) {
+                var status = xhr.status;
+
+                if ((status >= 200 && status < 300) || status === 304) {
+                    var doc = JSON.parse(xhr.responseText);
+                    mimeType = doc.mimeType;
+                    docName = getName(doc.path);
+                } else {
+                    document.getElementById('optMessage').innerHTML = "<div class='notice warning'><i class='icon-warning-sign icon-large'></i> " + "Configuration is NOT properly defined to let the application work or OpenKM not available." + "<a href='#close' class='icon-remove'></a></div>";
+                    console.log("Error: Configuration is NOT properly defined to let the application work or OpenKM not available" );
+                }
+            }
+        };
+        
+        xhr.send();
+        
+        if (mimeType.length>0) {
+            try {
+                var requestUrl = url + "services/rest/document/getContent?docId=" + uuid;
+                
+                xhr = new XMLHttpRequest();
+                xhr.open("GET", requestUrl);
+                
+                xhr.responseType = "arraybuffer";
+                
+                xhr.setRequestHeader("Authorization", "Basic " + btoa(userName + ":" + password));
+                xhr.setRequestHeader("Accept", "application/octet-stream");
+                
+                xhr.onload = function () {
+                    if (this.status === 200) {
+                        var blob = new Blob([xhr.response], {type: mimeType, name: docName});
+                        var objectUrl = URL.createObjectURL(blob);
+                        window.open(objectUrl);
+                    }
+                };
+                
+                xhr.send();
+            } catch (e) {
+                alert(e);
+            }
+        } 
+    });
+}

--- a/js/popup.js
+++ b/js/popup.js
@@ -101,17 +101,15 @@ function generateHtmlResultsWS1(jsonDict, baseUrl) {
     if (length>1) {
         for (var k = 0; k < length; k++) {
             var res = results[k];
-            if (isBrowserPreview(res["document"]["mimeType"])) {
-                var uuid = res["document"]["uuid"];
-                document.getElementById(uuid).addEventListener('click', function() {
-                    getContent(this.id);
-                });
-            }
+            var uuid = res["document"]["uuid"]; 
+            document.getElementById(uuid).addEventListener('click', function() {
+                getContent(this.id, isBrowserPreview(res["document"]["mimeType"]));
+            });
         }
     } else if (length==1) {
         var uuid = results["document"]["uuid"];
         document.getElementById(uuid).addEventListener('click', function() {
-            getContent(this.id);
+            getContent(this.id, isBrowserPreview(results["document"]["mimeType"]));
         });
     } 
 }
@@ -160,17 +158,15 @@ function generateHtmlResultsWS2(jsonDict, baseUrl) {
     if (length>1) {
         for (var k = 0; k < length; k++) {
             var res = results[k];
-            if (isBrowserPreview(res["node"]["mimeType"])) {
-                var uuid = res["node"]["uuid"];
-                document.getElementById(uuid).addEventListener('click', function() {
-                    getContent(this.id);
-                });
-            }
+            var uuid = res["node"]["uuid"];
+            document.getElementById(uuid).addEventListener('click', function() {
+                getContent(this.id, isBrowserPreview(res["node"]["mimeType"]));
+            });
         }
     } else if (length==1) {
         var uuid = results["node"]["uuid"];
         document.getElementById(uuid).addEventListener('click', function() {
-            getContent(this.id);
+            getContent(this.id, isBrowserPreview(results["node"]["mimeType"]));
         });
     } 
 }
@@ -178,15 +174,15 @@ function generateHtmlResultsWS2(jsonDict, baseUrl) {
 function generateRowWS(res, rootNodeName, baseUrl) {
     var newRow = "<tr class='result'>";
     // Setting the file name and the Download link
-    if (isBrowserPreview(res[rootNodeName]["mimeType"])) {
+//    if (isBrowserPreview(res[rootNodeName]["mimeType"])) {
         newRow += "<docname>" + getFileIconCode(res[rootNodeName]["mimeType"]);
         newRow += " <a href='#' id='"+res[rootNodeName]["uuid"]+"'>" + getName(res[rootNodeName]["path"]) + "</a>";
         newRow += "</docname>";
-    } else {
-        newRow += "<docname>" + getFileIconCode(res[rootNodeName]["mimeType"]);
-        newRow += " <a target='_blank' href='" + baseUrl + "Download?uuid=" + res[rootNodeName]["uuid"] + "'>" + getName(res[rootNodeName]["path"]) + "</a>"
-        newRow += "</docname>";
-    }
+//    } else {
+//        newRow += "<docname>" + getFileIconCode(res[rootNodeName]["mimeType"]);
+//        newRow += " <a target='_blank' href='" + baseUrl + "Download?uuid=" + res[rootNodeName]["uuid"] + "'>" + getName(res[rootNodeName]["path"]) + "</a>"
+//        newRow += "</docname>";
+//    }
     
     newRow += "<date>Date: " + res[rootNodeName]["actualVersion"]["created"].toString()+ "</date><br><br>";
     

--- a/js/popup.js
+++ b/js/popup.js
@@ -46,14 +46,7 @@ function getName(nodePath) {
     return nodePath.substring(nodePath.lastIndexOf('/')+1)
 }
 
-function isBrowserPreview(mimeType) {
-    if (mimeType == "application/pdf" || mimeType == "text/plain" || mimeType == "image/jpeg" || mimeType == "image/gif" || 
-            mimeType == "image/png" || mimeType == "image/bmp" || mimeType == "text/html" || mimeType == "text/plain") {
-        return true;
-    } else {
-        return false;
-    }
-}
+
 
 function generateHtmlResultsWS1(jsonDict, baseUrl) {
     // Grabbing the results
@@ -103,13 +96,13 @@ function generateHtmlResultsWS1(jsonDict, baseUrl) {
             var res = results[k];
             var uuid = res["document"]["uuid"]; 
             document.getElementById(uuid).addEventListener('click', function() {
-                getContent(this.id, isBrowserPreview(res["document"]["mimeType"]));
+                getContent(this.id);
             });
         }
     } else if (length==1) {
         var uuid = results["document"]["uuid"];
         document.getElementById(uuid).addEventListener('click', function() {
-            getContent(this.id, isBrowserPreview(results["document"]["mimeType"]));
+            getContent(this.id);
         });
     } 
 }
@@ -160,13 +153,13 @@ function generateHtmlResultsWS2(jsonDict, baseUrl) {
             var res = results[k];
             var uuid = res["node"]["uuid"];
             document.getElementById(uuid).addEventListener('click', function() {
-                getContent(this.id, isBrowserPreview(res["node"]["mimeType"]));
+                getContent(this.id);
             });
         }
     } else if (length==1) {
         var uuid = results["node"]["uuid"];
         document.getElementById(uuid).addEventListener('click', function() {
-            getContent(this.id, isBrowserPreview(results["node"]["mimeType"]));
+            getContent(this.id);
         });
     } 
 }
@@ -174,15 +167,13 @@ function generateHtmlResultsWS2(jsonDict, baseUrl) {
 function generateRowWS(res, rootNodeName, baseUrl) {
     var newRow = "<tr class='result'>";
     // Setting the file name and the Download link
-//    if (isBrowserPreview(res[rootNodeName]["mimeType"])) {
-        newRow += "<docname>" + getFileIconCode(res[rootNodeName]["mimeType"]);
-        newRow += " <a href='#' id='"+res[rootNodeName]["uuid"]+"'>" + getName(res[rootNodeName]["path"]) + "</a>";
-        newRow += "</docname>";
-//    } else {
-//        newRow += "<docname>" + getFileIconCode(res[rootNodeName]["mimeType"]);
-//        newRow += " <a target='_blank' href='" + baseUrl + "Download?uuid=" + res[rootNodeName]["uuid"] + "'>" + getName(res[rootNodeName]["path"]) + "</a>"
-//        newRow += "</docname>";
-//    }
+    newRow += "<docname>" + getFileIconCode(res[rootNodeName]["mimeType"]);
+    newRow += " <a href='#' id='"+res[rootNodeName]["uuid"]+"'>" + getName(res[rootNodeName]["path"]) + "</a>";
+    newRow += "</docname>";
+
+//    newRow += "<docname>" + getFileIconCode(res[rootNodeName]["mimeType"]);
+//    newRow += " <a target='_blank' href='" + baseUrl + "Download?uuid=" + res[rootNodeName]["uuid"] + "'>" + getName(res[rootNodeName]["path"]) + "</a>"
+//    newRow += "</docname>";
     
     newRow += "<date>Date: " + res[rootNodeName]["actualVersion"]["created"].toString()+ "</date><br><br>";
     

--- a/ui/popup.html
+++ b/ui/popup.html
@@ -93,6 +93,9 @@ Copyright (C) F. Brezo and Y. Rubio (i3visio) 2016
 <!-- Script to load things in the UI -->
 <script src="/js/popup.js"></script>
 
+<!-- Script to downlaod files from js -->
+<script src="/js/download.js"></script>
+
 <!-- Script needed to translate the given interface onto a different language. This MUST be the latest thing in the document. -->
 <script src="/js/localize.js"></script>
 

--- a/ui/popup.html
+++ b/ui/popup.html
@@ -90,6 +90,9 @@ Copyright (C) F. Brezo and Y. Rubio (i3visio) 2016
 	<br>
 </div>
 
+<!-- Iframe for downloading files -->
+<iframe src="" name="__download" id="__download" style="width:0; height:0; border:0;"></iframe>
+
 <!-- Script to load things in the UI -->
 <script src="/js/popup.js"></script>
 

--- a/ui/popup.html
+++ b/ui/popup.html
@@ -90,9 +90,6 @@ Copyright (C) F. Brezo and Y. Rubio (i3visio) 2016
 	<br>
 </div>
 
-<!-- Iframe for downloading files -->
-<iframe src="" name="__download" id="__download" style="width:0; height:0; border:0;"></iframe>
-
 <!-- Script to load things in the UI -->
 <script src="/js/popup.js"></script>
 


### PR DESCRIPTION
Preview files from new tab ( only mime types compliants with browser support ) or direct download without requiring new authentication.

Compatible with older WS 1.0.

Note: Consider applying the previous pull request first.
